### PR TITLE
GSList to GPtrArray

### DIFF
--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -77,6 +77,15 @@ Query2 get_catalog_top_n_drivers_by_score(Catalog c, int N);
 Query3 get_catalog_top_n_users_by_distance(Catalog c, int N);
 
 /**
+ * @brief Get the catalog city avg cost object
+ *
+ * @param c
+ * @param city
+ * @return double
+ */
+double get_catalog_city_avg_cost(Catalog c, char *city);
+
+/**
  * @brief Get the catalog rides object
  *
  * @param c

--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -28,9 +28,9 @@ Catalog new_catalog();
 void free_catalog(Catalog c);
 
 /**
- * @brief 
- * 
- * @param q3 
+ * @brief
+ *
+ * @param q3
  */
 void free_query3(Query3 q3);
 

--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -9,7 +9,7 @@ typedef struct driver *Driver;
 typedef GHashTable *Users;
 typedef GHashTable *Drivers;
 typedef GPtrArray *Rides;
-typedef GSList *Query2;
+typedef GPtrArray *Query2;
 typedef GSList *Query3;
 typedef struct catalog *Catalog;
 

--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -10,7 +10,7 @@ typedef GHashTable *Users;
 typedef GHashTable *Drivers;
 typedef GPtrArray *Rides;
 typedef GPtrArray *Query2;
-typedef GSList *Query3;
+typedef GPtrArray *Query3;
 typedef struct catalog *Catalog;
 
 /**

--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -8,7 +8,7 @@ typedef struct user *User;
 typedef struct driver *Driver;
 typedef GHashTable *Users;
 typedef GHashTable *Drivers;
-typedef GSList *Rides;
+typedef GPtrArray *Rides;
 typedef GSList *Query2;
 typedef GSList *Query3;
 typedef struct catalog *Catalog;

--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -8,7 +8,7 @@ typedef struct user *User;
 typedef struct driver *Driver;
 typedef GHashTable *Users;
 typedef GHashTable *Drivers;
-typedef GPtrArray *Rides;
+typedef GArray *Rides;
 typedef GPtrArray *Query2;
 typedef GPtrArray *Query3;
 typedef struct catalog *Catalog;

--- a/trabalho-pratico/includes/model/drivers.h
+++ b/trabalho-pratico/includes/model/drivers.h
@@ -14,9 +14,9 @@ typedef GHashTable *Drivers;
 Drivers new_drivers(void);
 
 /**
- * @brief 
- * 
- * @param drivers 
+ * @brief
+ *
+ * @param drivers
  */
 void free_drivers(Drivers drivers);
 

--- a/trabalho-pratico/includes/model/query2.h
+++ b/trabalho-pratico/includes/model/query2.h
@@ -3,7 +3,7 @@
 
 #include <glib.h>
 
-typedef GSList *Query2;
+typedef GPtrArray *Query2;
 typedef GHashTable *Drivers;
 
 /**
@@ -22,18 +22,10 @@ Query2 new_query2(Drivers drivers);
 void free_query2(Query2 q2);
 
 /**
- * @brief
- *
- * @param q2
+ * @brief 
+ * 
+ * @param q2 
  */
-void free_query2_full(Query2 q2);
-
-/**
- * @brief
- *
- * @param q2
- * @return Query2
- */
-Query2 sort_query2(Query2 q2);
+void sort_query2(Query2 q2);
 
 #endif

--- a/trabalho-pratico/includes/model/query2.h
+++ b/trabalho-pratico/includes/model/query2.h
@@ -7,32 +7,32 @@ typedef GSList *Query2;
 typedef GHashTable *Drivers;
 
 /**
- * @brief 
- * 
- * @param drivers 
- * @return Query2 
+ * @brief
+ *
+ * @param drivers
+ * @return Query2
  */
 Query2 new_query2(Drivers drivers);
 
 /**
- * @brief 
- * 
- * @param q2 
+ * @brief
+ *
+ * @param q2
  */
 void free_query2(Query2 q2);
 
 /**
- * @brief 
- * 
- * @param q2 
+ * @brief
+ *
+ * @param q2
  */
 void free_query2_full(Query2 q2);
 
 /**
- * @brief 
- * 
- * @param q2 
- * @return Query2 
+ * @brief
+ *
+ * @param q2
+ * @return Query2
  */
 Query2 sort_query2(Query2 q2);
 

--- a/trabalho-pratico/includes/model/query3.h
+++ b/trabalho-pratico/includes/model/query3.h
@@ -7,32 +7,32 @@ typedef GSList *Query3;
 typedef GHashTable *Users;
 
 /**
- * @brief 
- * 
- * @param drivers 
+ * @brief
+ *
+ * @param drivers
  * @return Query3
  */
 Query3 new_query3(Users users);
 
 /**
- * @brief 
- * 
- * @param q3 
+ * @brief
+ *
+ * @param q3
  */
 void free_query3(Query3 q3);
 
 /**
- * @brief 
- * 
- * @param q3 
+ * @brief
+ *
+ * @param q3
  */
 void free_query3_full(Query3 q3);
 
 /**
- * @brief 
- * 
- * @param q3 
- * @return Query3 
+ * @brief
+ *
+ * @param q3
+ * @return Query3
  */
 Query3 sort_query3(Query3 q3);
 

--- a/trabalho-pratico/includes/model/query3.h
+++ b/trabalho-pratico/includes/model/query3.h
@@ -3,7 +3,7 @@
 
 #include <glib.h>
 
-typedef GSList *Query3;
+typedef GPtrArray *Query3;
 typedef GHashTable *Users;
 
 /**
@@ -29,11 +29,10 @@ void free_query3(Query3 q3);
 void free_query3_full(Query3 q3);
 
 /**
- * @brief
- *
- * @param q3
- * @return Query3
+ * @brief 
+ * 
+ * @param q3 
  */
-Query3 sort_query3(Query3 q3);
+void sort_query3(Query3 q3);
 
 #endif

--- a/trabalho-pratico/includes/model/query4.h
+++ b/trabalho-pratico/includes/model/query4.h
@@ -1,0 +1,40 @@
+#ifndef __QUERY4_H__
+#define __QUERY4_H__
+
+#include <glib.h>
+
+typedef GHashTable *Query4;
+
+/**
+ * @brief
+ *
+ * @return Query4
+ */
+Query4 new_query4(void);
+
+/**
+ * @brief
+ *
+ * @param q4
+ */
+void free_query4(Query4 q4);
+
+/**
+ * @brief
+ *
+ * @param q4
+ * @param city
+ * @param cost
+ */
+void add_query4_ride_cost(Query4 q4, char *city, double cost);
+
+/**
+ * @brief Get the query4 city avg cost object
+ *
+ * @param q4
+ * @param city
+ * @return double
+ */
+double get_query4_city_avg_cost(Query4 q4, char *city);
+
+#endif

--- a/trabalho-pratico/includes/model/query4.h
+++ b/trabalho-pratico/includes/model/query4.h
@@ -4,6 +4,7 @@
 #include <glib.h>
 
 typedef GHashTable *Query4;
+typedef struct ride *Ride;
 
 /**
  * @brief
@@ -26,7 +27,7 @@ void free_query4(Query4 q4);
  * @param city
  * @param cost
  */
-void add_query4_ride_cost(Query4 q4, char *city, double cost);
+void add_query4_ride(Query4 q4, Ride r);
 
 /**
  * @brief Get the query4 city avg cost object

--- a/trabalho-pratico/includes/model/ride.h
+++ b/trabalho-pratico/includes/model/ride.h
@@ -31,7 +31,7 @@ Ride new_ride(void);
  *
  * @param ride
  */
-void free_ride(void *ride);
+void free_ride(Ride *r);
 
 /**
  * @brief Set the ride id object

--- a/trabalho-pratico/includes/model/rides.h
+++ b/trabalho-pratico/includes/model/rides.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 
 typedef struct ride *Ride;
-typedef GPtrArray *Rides;
+typedef GArray *Rides;
 
 /**
  * @brief 

--- a/trabalho-pratico/includes/model/rides.h
+++ b/trabalho-pratico/includes/model/rides.h
@@ -16,9 +16,9 @@ typedef GSList *Rides;
 Rides insert_ride(Rides rides, Ride ride);
 
 /**
- * @brief 
- * 
- * @param rides 
+ * @brief
+ *
+ * @param rides
  */
 void free_rides(Rides rides);
 

--- a/trabalho-pratico/includes/model/rides.h
+++ b/trabalho-pratico/includes/model/rides.h
@@ -22,4 +22,12 @@ Rides insert_ride(Rides rides, Ride ride);
  */
 void free_rides(Rides rides);
 
+/**
+ * @brief 
+ * 
+ * @param rides 
+ * @return Rides 
+ */
+Rides sort_rides(Rides rides);
+
 #endif

--- a/trabalho-pratico/includes/model/rides.h
+++ b/trabalho-pratico/includes/model/rides.h
@@ -4,16 +4,22 @@
 #include <glib.h>
 
 typedef struct ride *Ride;
-typedef GSList *Rides;
+typedef GPtrArray *Rides;
 
 /**
- * @brief
- *
- * @param rides
- * @param ride
- * @return Rides
+ * @brief 
+ * 
+ * @return Rides 
  */
-Rides insert_ride(Rides rides, Ride ride);
+Rides new_rides(void);
+
+/**
+ * @brief 
+ * 
+ * @param rides 
+ * @param ride 
+ */
+void add_ride(Rides rides, Ride ride);
 
 /**
  * @brief
@@ -26,8 +32,7 @@ void free_rides(Rides rides);
  * @brief 
  * 
  * @param rides 
- * @return Rides 
  */
-Rides sort_rides(Rides rides);
+void sort_rides(Rides rides);
 
 #endif

--- a/trabalho-pratico/includes/model/users.h
+++ b/trabalho-pratico/includes/model/users.h
@@ -15,9 +15,9 @@ typedef GHashTable *Users;
 Users new_users(void);
 
 /**
- * @brief 
- * 
- * @param users 
+ * @brief
+ *
+ * @param users
  */
 void free_users(Users users);
 

--- a/trabalho-pratico/includes/view/ui.h
+++ b/trabalho-pratico/includes/view/ui.h
@@ -36,4 +36,11 @@ void show_query2(Query2 q2);
  */
 void show_query3(Query3 q3);
 
+/**
+ * @brief
+ *
+ * @param avg_score
+ */
+void show_query4(double avg_score);
+
 #endif

--- a/trabalho-pratico/includes/view/ui.h
+++ b/trabalho-pratico/includes/view/ui.h
@@ -5,7 +5,7 @@
 
 typedef struct user *User;
 typedef struct driver *Driver;
-typedef GSList *Query2;
+typedef GPtrArray *Query2;
 typedef GSList *Query3;
 
 /**

--- a/trabalho-pratico/includes/view/ui.h
+++ b/trabalho-pratico/includes/view/ui.h
@@ -6,7 +6,7 @@
 typedef struct user *User;
 typedef struct driver *Driver;
 typedef GPtrArray *Query2;
-typedef GSList *Query3;
+typedef GPtrArray *Query3;
 
 /**
  * @brief

--- a/trabalho-pratico/src/controller/controller.c
+++ b/trabalho-pratico/src/controller/controller.c
@@ -67,7 +67,7 @@ int parse_query(Catalog c, char *query)
             sscanf(query, "%*d %d", &N);
             Query2 q2 = get_catalog_top_n_drivers_by_score(c, N);
             show_query2(q2);
-            free_query2_full(q2);
+            free_query2(q2);
             break;
         case '3':
             sscanf(query, "%*d %d", &N);

--- a/trabalho-pratico/src/controller/controller.c
+++ b/trabalho-pratico/src/controller/controller.c
@@ -73,7 +73,7 @@ int parse_query(Catalog c, char *query)
             sscanf(query, "%*d %d", &N);
             Query3 q3 = get_catalog_top_n_users_by_distance(c, N);
             show_query3(q3);
-            free_query3_full(q3);
+            free_query3(q3);
             break;
         case '4':
             char city[64];

--- a/trabalho-pratico/src/controller/controller.c
+++ b/trabalho-pratico/src/controller/controller.c
@@ -9,8 +9,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <glib.h>
-
 int run_controller(char *path_inputs, char *path_queries)
 {
     Catalog c = new_catalog();

--- a/trabalho-pratico/src/controller/controller.c
+++ b/trabalho-pratico/src/controller/controller.c
@@ -78,7 +78,9 @@ int parse_query(Catalog c, char *query)
             free_query3_full(q3);
             break;
         case '4':
-            printf("Query 4\n");
+            char city[64];
+            sscanf(query, "%*d %s", city);
+            show_query4(get_catalog_city_avg_cost(c, city));
             break;
         case '5':
             printf("Query 5\n");

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -33,7 +33,7 @@ int process_catalog(Catalog c)
     guint n_rides = c->rides->len;
 
     for (guint i = 0; i < n_rides; i ++) {
-        Ride r = g_ptr_array_index(c->rides, i);
+        Ride r = g_array_index(c->rides, Ride, i);
         long d_id = get_ride_driver(r);
         Driver d = get_driver(c->drivers, d_id);
         set_ride_cost(r, d);

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -26,13 +26,14 @@ Catalog new_catalog()
     return c;
 }
 
-#include <stdio.h>
 int process_catalog(Catalog c)
 {
-    c->rides = sort_rides(c->rides);
+    sort_rides(c->rides);
 
-    for (Rides iterator = c->rides; iterator; iterator = iterator->next) {
-        Ride r = iterator->data;
+    guint n_rides = c->rides->len;
+
+    for (guint i = 0; i < n_rides; i ++) {
+        Ride r = g_ptr_array_index(c->rides, i);
         long d_id = get_ride_driver(r);
         Driver d = get_driver(c->drivers, d_id);
         set_ride_cost(r, d);
@@ -41,7 +42,6 @@ int process_catalog(Catalog c)
         User u = get_users_user(c->users, username);
         free(username);
         add_user_ride_data(u, r);
-        // replace with add ride to city with complete parameters
         add_query4_ride(c->query4, r);
     }
 

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -49,7 +49,7 @@ int process_catalog(Catalog c)
     remove_inactive_drivers(c->drivers);
 
     c->query2 = new_query2(c->drivers);
-    c->query2 = sort_query2(c->query2);
+    sort_query2(c->query2);
 
     c->query3 = new_query3(c->users);
     c->query3 = sort_query3(c->query3);
@@ -90,13 +90,13 @@ Rides get_catalog_rides(Catalog c)
 
 Query2 get_catalog_top_n_drivers_by_score(Catalog c, int N)
 {
-    Query2 r = NULL;
+    Query2 r = g_ptr_array_new_full(N, free_driver);
 
-    for (Query2 itr = c->query2; itr && N; itr = itr->next, N--) {
-        r = g_slist_prepend(r, copy_driver(itr->data));
+    for (int i = 0; i < N; i ++) {
+        g_ptr_array_add(r, copy_driver(g_ptr_array_index(c->query2, i)));
     }
 
-    return g_slist_reverse(r);
+    return r;
 }
 
 Query3 get_catalog_top_n_users_by_distance(Catalog c, int N)

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -26,8 +26,11 @@ Catalog new_catalog()
     return c;
 }
 
+#include <stdio.h>
 int process_catalog(Catalog c)
 {
+    c->rides = sort_rides(c->rides);
+
     for (Rides iterator = c->rides; iterator; iterator = iterator->next) {
         Ride r = iterator->data;
         long d_id = get_ride_driver(r);
@@ -38,9 +41,8 @@ int process_catalog(Catalog c)
         User u = get_users_user(c->users, username);
         free(username);
         add_user_ride_data(u, r);
-        double cost = get_ride_cost(r);
-        char *city = get_ride_city(r);
-        add_query4_ride_cost(c->query4, city, cost);
+        // replace with add ride to city with complete parameters
+        add_query4_ride(c->query4, r);
     }
 
     remove_inactive_users(c->users);

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -52,7 +52,7 @@ int process_catalog(Catalog c)
     sort_query2(c->query2);
 
     c->query3 = new_query3(c->users);
-    c->query3 = sort_query3(c->query3);
+    sort_query3(c->query3);
 
     return 0;
 }
@@ -101,13 +101,13 @@ Query2 get_catalog_top_n_drivers_by_score(Catalog c, int N)
 
 Query3 get_catalog_top_n_users_by_distance(Catalog c, int N)
 {
-    Query3 r = NULL;
+    Query3 r = g_ptr_array_new_full(N, free_user);
 
-    for (Query3 itr = c->query3; itr && N; itr = itr->next, N--) {
-        r = g_slist_prepend(r, copy_user(itr->data));
+    for (int i = 0; i < N; i ++) {
+        g_ptr_array_add(r, copy_user(g_ptr_array_index(c->query3, i)));
     }
 
-    return g_slist_reverse(r);
+    return r;
 }
 
 double get_catalog_city_avg_cost(Catalog c, char *city)

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -9,17 +9,27 @@
 #include "users.h"
 #include <glib.h>
 
+typedef GHashTable *Query4;
+
+typedef struct aux4 {
+    double sum_costs;
+    int n_rides;
+} * Aux4;
+
 struct catalog {
     Users users;
     Drivers drivers;
     Rides rides;
     Query2 query2;
     Query3 query3;
+    Query4 query4;
 };
 
 Catalog new_catalog()
 {
-    return g_new(struct catalog, 1);
+    Catalog c = g_new(struct catalog, 1);
+    c->query4 = g_hash_table_new(g_str_hash, g_str_equal);
+    return c;
 }
 
 int process_catalog(Catalog c)
@@ -34,6 +44,21 @@ int process_catalog(Catalog c)
         User u = get_users_user(c->users, username);
         free(username);
         add_user_ride_data(u, r);
+
+        double cost = get_ride_cost(r);
+        char *city = get_ride_city(r);
+        Aux4 foo = g_hash_table_lookup(c->query4, city);
+        if (foo != NULL) {
+            foo->sum_costs += cost;
+            foo->n_rides++;
+            free(city);
+        }
+        else {
+            Aux4 bar = g_new(struct aux4, 1);
+            bar->sum_costs = cost;
+            bar->n_rides = 1;
+            g_hash_table_insert(c->query4, city, bar);
+        }
     }
 
     remove_inactive_users(c->users);

--- a/trabalho-pratico/src/model/db.c
+++ b/trabalho-pratico/src/model/db.c
@@ -158,7 +158,7 @@ static Rides _load_rides(FILE *fp)
 {
     char *line = NULL;
     size_t len = 0;
-    Rides rides = NULL;
+    Rides rides = new_rides();
 
     getline(&line, &len, fp); // Remove header
 
@@ -202,7 +202,7 @@ static Rides _load_rides(FILE *fp)
             }
         }
 
-        rides = insert_ride(rides, ride);
+        add_ride(rides, ride);
     }
 
     free(line);

--- a/trabalho-pratico/src/model/query2.c
+++ b/trabalho-pratico/src/model/query2.c
@@ -7,28 +7,30 @@ static gint _driver_comparator(gconstpointer driver1, gconstpointer driver2);
 
 Query2 new_query2(Drivers drivers)
 {
-    return (Query2)g_hash_table_get_values(drivers);
+    Query2 q2 = g_ptr_array_sized_new(g_hash_table_size(drivers));
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, drivers);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
+        g_ptr_array_add(q2, value);
+    }
+    return q2;
 }
 
 void free_query2(Query2 q2)
 {
-    g_slist_free(q2);
+    g_ptr_array_free(q2, TRUE);
 }
 
-void free_query2_full(Query2 q2)
+void sort_query2(Query2 q2)
 {
-    g_slist_free_full(q2, free_driver);
+    g_ptr_array_sort(q2, (GCompareFunc)_driver_comparator);
 }
 
-Query2 sort_query2(Query2 q2)
+static gint _driver_comparator(gconstpointer a, gconstpointer b)
 {
-    return g_slist_sort(q2, (GCompareFunc)_driver_comparator);
-}
-
-static gint _driver_comparator(gconstpointer driver1, gconstpointer driver2)
-{
-    Driver d1 = (Driver)driver1;
-    Driver d2 = (Driver)driver2;
+    Driver d1 = *((Driver *)a);
+    Driver d2 = *((Driver *)b);
 
     float score1 = get_driver_avg_score(d1);
     float score2 = get_driver_avg_score(d2);

--- a/trabalho-pratico/src/model/query2.c
+++ b/trabalho-pratico/src/model/query2.c
@@ -1,6 +1,6 @@
 #include "query2.h"
-#include "drivers.h"
 #include "driver.h"
+#include "drivers.h"
 #include <glib.h>
 
 static gint _driver_comparator(gconstpointer driver1, gconstpointer driver2);

--- a/trabalho-pratico/src/model/query3.c
+++ b/trabalho-pratico/src/model/query3.c
@@ -7,28 +7,30 @@ static gint _user_comparator(gconstpointer user1, gconstpointer user2);
 
 Query3 new_query3(Users users)
 {
-    return (Query3)g_hash_table_get_values(users);
+    Query3 q3 = g_ptr_array_sized_new(g_hash_table_size(users));
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, users);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
+        g_ptr_array_add(q3, value);
+    }
+    return q3;
 }
 
 void free_query3(Query3 q3)
 {
-    g_slist_free(q3);
+    g_ptr_array_free(q3, TRUE);
 }
 
-void free_query3_full(Query3 q3)
+void sort_query3(Query3 q3)
 {
-    g_slist_free_full(q3, free_user);
+    g_ptr_array_sort(q3, (GCompareFunc)_user_comparator);
 }
 
-Query3 sort_query3(Query3 q3)
+static gint _user_comparator(gconstpointer a, gconstpointer b)
 {
-    return g_slist_sort(q3, (GCompareFunc)_user_comparator);
-}
-
-static gint _user_comparator(gconstpointer user1, gconstpointer user2)
-{
-    User u1 = (User)user1;
-    User u2 = (User)user2;
+    User u1 = *((User *)a);
+    User u2 = *((User *)b);
 
     unsigned short distance1 = get_user_total_distance(u1);
     unsigned short distance2 = get_user_total_distance(u2);

--- a/trabalho-pratico/src/model/query3.c
+++ b/trabalho-pratico/src/model/query3.c
@@ -1,6 +1,6 @@
 #include "query3.h"
-#include "users.h"
 #include "user.h"
+#include "users.h"
 #include <glib.h>
 
 static gint _user_comparator(gconstpointer user1, gconstpointer user2);

--- a/trabalho-pratico/src/model/query4.c
+++ b/trabalho-pratico/src/model/query4.c
@@ -1,0 +1,54 @@
+#include "query4.h"
+#include <glib.h>
+
+typedef struct city {
+    double sum_costs;
+    int n_rides;
+} * City;
+
+static void _key_destroyed(gpointer data);
+static void _value_destroyed(gpointer data);
+
+Query4 new_query4(void)
+{
+    return g_hash_table_new_full(g_str_hash, g_str_equal,
+                                 (GDestroyNotify)_key_destroyed,
+                                 (GDestroyNotify)_value_destroyed);
+}
+
+void free_query4(Query4 q4)
+{
+    g_hash_table_destroy(g_steal_pointer(&q4));
+}
+
+void add_query4_ride_cost(Query4 q4, char *city, double cost)
+{
+    City found = g_hash_table_lookup(q4, city);
+    if (found != NULL) {
+        found->sum_costs += cost;
+        found->n_rides++;
+        free(city);
+    }
+    else {
+        City new = g_new(struct city, 1);
+        new->sum_costs = cost;
+        new->n_rides = 1;
+        g_hash_table_insert(q4, city, new);
+    }
+}
+
+double get_query4_city_avg_cost(Query4 q4, char *city)
+{
+    City c = g_hash_table_lookup(q4, city);
+    return c->sum_costs / c->n_rides;
+}
+
+static void _key_destroyed(gpointer data)
+{
+    g_free(data);
+}
+
+static void _value_destroyed(gpointer data)
+{
+    g_free(data);
+}

--- a/trabalho-pratico/src/model/query4.c
+++ b/trabalho-pratico/src/model/query4.c
@@ -1,4 +1,5 @@
 #include "query4.h"
+#include "ride.h"
 #include <glib.h>
 
 typedef struct city {
@@ -21,8 +22,10 @@ void free_query4(Query4 q4)
     g_hash_table_destroy(g_steal_pointer(&q4));
 }
 
-void add_query4_ride_cost(Query4 q4, char *city, double cost)
+void add_query4_ride(Query4 q4, Ride r)
 {
+    double cost = get_ride_cost(r);
+    char *city = get_ride_city(r);
     City found = g_hash_table_lookup(q4, city);
     if (found != NULL) {
         found->sum_costs += cost;

--- a/trabalho-pratico/src/model/ride.c
+++ b/trabalho-pratico/src/model/ride.c
@@ -23,14 +23,11 @@ Ride new_ride(void)
     return g_new(struct ride, 1);
 }
 
-void free_ride(void *ride)
+void free_ride(Ride *r)
 {
-    if (ride != NULL) {
-        Ride r = (Ride)ride;
-        free(r->user);
-        free(r->city);
-        free(ride);
-    }
+    free((*r)->user);
+    free((*r)->city);
+    free(*r);
 }
 
 void set_ride_id(Ride r, char *id)

--- a/trabalho-pratico/src/model/rides.c
+++ b/trabalho-pratico/src/model/rides.c
@@ -2,12 +2,13 @@
 #include "ride.h"
 #include <glib.h>
 
+#define DEFAULT_SIZE 1000000 // ? ou 1048576 (2^20)
+
 static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2);
 
 Rides new_rides(void)
 {
-    return g_ptr_array_new_full(1000000, free_ride);
-    //return g_ptr_array_new_with_free_func(free_ride);
+    return g_ptr_array_new_full(DEFAULT_SIZE, free_ride);
 }
 
 void add_ride(Rides rides, Ride ride)

--- a/trabalho-pratico/src/model/rides.c
+++ b/trabalho-pratico/src/model/rides.c
@@ -2,33 +2,35 @@
 #include "ride.h"
 #include <glib.h>
 
-#define DEFAULT_SIZE 1000000 // ? ou 1048576 (2^20)
+#define RESERVED_SIZE 1048576 // (2^20)
 
 static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2);
 
 Rides new_rides(void)
 {
-    return g_ptr_array_new_full(DEFAULT_SIZE, free_ride);
+    Rides r = g_array_sized_new(FALSE, FALSE, sizeof(Ride), RESERVED_SIZE);
+    g_array_set_clear_func (r, (GDestroyNotify)free_ride);
+    return r;
 }
 
 void add_ride(Rides rides, Ride ride)
 {
-    g_ptr_array_add(rides, (gpointer)ride);
+    g_array_append_val(rides, ride);
 }
 
 void free_rides(Rides rides)
 {
-    g_ptr_array_free(rides, TRUE);
+    g_array_free(rides, TRUE);
 }
 
 void sort_rides(Rides rides)
 {
-    g_ptr_array_sort(rides, (GCompareFunc)_ride_comparator);
+    g_array_sort(rides, (GCompareFunc)_ride_comparator);
 }
 
 static gint _ride_comparator(gconstpointer a, gconstpointer b)
 {
-    const Ride r1 = *((Ride *)a);
-    const Ride r2 = *((Ride *)b);
+    const Ride r1 = (Ride)a;
+    const Ride r2 = (Ride)b;
     return get_ride_date(r1) - get_ride_date(r2);
 }

--- a/trabalho-pratico/src/model/rides.c
+++ b/trabalho-pratico/src/model/rides.c
@@ -4,22 +4,29 @@
 
 static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2);
 
-Rides insert_ride(Rides rides, Ride ride)
+Rides new_rides(void)
 {
-    return g_slist_prepend(rides, ride);
+    return g_ptr_array_new_with_free_func(free_ride);
+}
+
+void add_ride(Rides rides, Ride ride)
+{
+    g_ptr_array_add(rides, (gpointer)ride);
 }
 
 void free_rides(Rides rides)
 {
-    g_slist_free_full(rides, free_ride);
+    g_ptr_array_free(rides, TRUE);
 }
 
-Rides sort_rides(Rides rides)
+void sort_rides(Rides rides)
 {
-    return g_slist_sort(rides, (GCompareFunc)_ride_comparator);
+    g_ptr_array_sort(rides, (GCompareFunc)_ride_comparator);
 }
 
-static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2)
+static gint _ride_comparator(gconstpointer a, gconstpointer b)
 {
-    return get_ride_date((Ride)ride2) - get_ride_date((Ride)ride1);
+    const Ride r1 = *((Ride *)a);
+    const Ride r2 = *((Ride *)b);
+    return get_ride_date(r1) - get_ride_date(r2);
 }

--- a/trabalho-pratico/src/model/rides.c
+++ b/trabalho-pratico/src/model/rides.c
@@ -6,7 +6,8 @@ static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2);
 
 Rides new_rides(void)
 {
-    return g_ptr_array_new_with_free_func(free_ride);
+    return g_ptr_array_new_full(1000000, free_ride);
+    //return g_ptr_array_new_with_free_func(free_ride);
 }
 
 void add_ride(Rides rides, Ride ride)

--- a/trabalho-pratico/src/model/rides.c
+++ b/trabalho-pratico/src/model/rides.c
@@ -1,5 +1,8 @@
 #include "rides.h"
 #include "ride.h"
+#include <glib.h>
+
+static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2);
 
 Rides insert_ride(Rides rides, Ride ride)
 {
@@ -9,4 +12,14 @@ Rides insert_ride(Rides rides, Ride ride)
 void free_rides(Rides rides)
 {
     g_slist_free_full(rides, free_ride);
+}
+
+Rides sort_rides(Rides rides)
+{
+    return g_slist_sort(rides, (GCompareFunc)_ride_comparator);
+}
+
+static gint _ride_comparator(gconstpointer ride1, gconstpointer ride2)
+{
+    return get_ride_date((Ride)ride2) - get_ride_date((Ride)ride1);
 }

--- a/trabalho-pratico/src/view/ui.c
+++ b/trabalho-pratico/src/view/ui.c
@@ -51,8 +51,8 @@ void show_query2(Query2 q2)
 
     char answer[256];
 
-    for (Query2 itr = q2; itr; itr = itr->next) {
-        Driver d = (Driver)itr->data;
+    for (guint i = 0; i < q2->len; i ++) {
+        Driver d = (Driver)g_ptr_array_index(q2, i);
         char *name = get_driver_name(d);
         sprintf(answer, "%012ld;%s;%.3f", get_driver_id(d), name,
                 get_driver_avg_score(d));

--- a/trabalho-pratico/src/view/ui.c
+++ b/trabalho-pratico/src/view/ui.c
@@ -83,3 +83,12 @@ void show_query3(Query3 q3)
 
     fclose(command_out);
 }
+
+void show_query4(double avg_score)
+{
+    char s[64];
+    sprintf(s, "./Resultados/command%d_output.txt", counter++);
+    FILE *command_out = fopen(s, "w");
+    fprintf(command_out, "%.3f\n", avg_score);
+    fclose(command_out);
+}

--- a/trabalho-pratico/src/view/ui.c
+++ b/trabalho-pratico/src/view/ui.c
@@ -71,8 +71,8 @@ void show_query3(Query3 q3)
 
     char answer[256];
 
-    for (Query3 itr = q3; itr; itr = itr->next) {
-        User u = (User)itr->data;
+    for (guint i = 0; i < q3->len; i ++) {
+        User u = (User)g_ptr_array_index(q3, i);
         char *name = get_user_name(u);
         char *username = get_user_username(u);
         sprintf(answer, "%s;%s;%d", username, name, get_user_total_distance(u));


### PR DESCRIPTION
Changed every use of a [GSList](https://docs.gtk.org/glib/struct.SList.html) to [GPtrArray](https://docs.gtk.org/glib/struct.PtrArray.html). This includes:
- Rides
- Query2
- Query3

Valgrind shows that this has reduced the number of allocs by almost 1,110,000:

Before:

    total heap usage: 7,023,557 allocs, 7,023,548 frees, 144,025,467 bytes allocated

After:

    total heap usage: 5,918,972 allocs, 5,918,963 frees, 143,921,338 bytes allocated

This makes sense as the number of pointers used to link the previous linked lists was exactly 1,110,000.

The number of total bytes allocated has also decreased slightly, but this is only possible if the GPtrArray used for rides is pre allocated, avoiding reallocs. Otherwide, this number would be above 150,000,000 bytes.