### PR TITLE
Rides back to GPtrArray from GArray

### DIFF
--- a/trabalho-pratico/includes/model/catalog.h
+++ b/trabalho-pratico/includes/model/catalog.h
@@ -8,7 +8,7 @@ typedef struct user *User;
 typedef struct driver *Driver;
 typedef GHashTable *Users;
 typedef GHashTable *Drivers;
-typedef GArray *Rides;
+typedef GPtrArray *Rides;
 typedef GPtrArray *Query2;
 typedef GPtrArray *Query3;
 typedef struct catalog *Catalog;

--- a/trabalho-pratico/includes/model/cities.h
+++ b/trabalho-pratico/includes/model/cities.h
@@ -5,7 +5,7 @@
 
 typedef GHashTable *Cities;
 typedef struct ride *Ride;
-typedef GArray *Rides;
+typedef GPtrArray *Rides;
 
 /**
  * @brief

--- a/trabalho-pratico/includes/model/drivers.h
+++ b/trabalho-pratico/includes/model/drivers.h
@@ -27,7 +27,7 @@ void free_drivers(Drivers drivers);
  * @param d
  * @return gboolean
  */
-gboolean insert_driver(Drivers drivers, Driver d);
+gboolean add_drivers_driver(Drivers drivers, Driver d);
 
 /**
  * @brief Get the driver object
@@ -36,7 +36,7 @@ gboolean insert_driver(Drivers drivers, Driver d);
  * @param id
  * @return Driver
  */
-Driver get_driver(Drivers drivers, long id);
+Driver get_drivers_driver(Drivers drivers, long id);
 
 /**
  * @brief

--- a/trabalho-pratico/includes/model/ride.h
+++ b/trabalho-pratico/includes/model/ride.h
@@ -31,7 +31,7 @@ Ride new_ride(void);
  *
  * @param ride
  */
-void free_ride(Ride *r);
+void free_ride(void *ride);
 
 /**
  * @brief Set the ride id object

--- a/trabalho-pratico/includes/model/rides.h
+++ b/trabalho-pratico/includes/model/rides.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 
 typedef struct ride *Ride;
-typedef GArray *Rides;
+typedef GPtrArray *Rides;
 
 /**
  * @brief
@@ -17,16 +17,25 @@ Rides new_rides(void);
  * @brief
  *
  * @param rides
- * @param ride
  */
-void add_ride(Rides rides, Ride ride);
+void free_rides(Rides rides);
 
 /**
  * @brief
  *
  * @param rides
+ * @param ride
  */
-void free_rides(Rides rides);
+void add_rides_ride(Rides rides, Ride ride);
+
+/**
+ * @brief Get the rides ride object
+ * 
+ * @param rides 
+ * @param index 
+ * @return Ride 
+ */
+Ride get_rides_ride(Rides rides, guint index);
 
 /**
  * @brief

--- a/trabalho-pratico/includes/model/users.h
+++ b/trabalho-pratico/includes/model/users.h
@@ -28,7 +28,7 @@ void free_users(Users users);
  * @param u
  * @return gboolean
  */
-gboolean insert_user(Users users, User u);
+gboolean add_users_user(Users users, User u);
 
 /**
  * @brief Get the user object

--- a/trabalho-pratico/src/model/catalog.c
+++ b/trabalho-pratico/src/model/catalog.c
@@ -33,9 +33,9 @@ int process_catalog(Catalog c)
     guint n_rides = c->rides->len;
 
     for (guint i = 0; i < n_rides; i++) {
-        Ride r = g_array_index(c->rides, Ride, i);
+        Ride r = get_rides_ride(c->rides, i);
         long d_id = get_ride_driver(r);
-        Driver d = get_driver(c->drivers, d_id);
+        Driver d = get_drivers_driver(c->drivers, d_id);
         set_ride_cost(r, d);
         add_driver_ride_data(d, r);
         char *username = get_ride_user(r);
@@ -90,7 +90,7 @@ User get_catalog_user(Catalog c, char *username)
 
 Driver get_catalog_driver(Catalog c, long id)
 {
-    return copy_driver(get_driver(c->drivers, id));
+    return copy_driver(get_drivers_driver(c->drivers, id));
 }
 
 Query2 get_catalog_top_n_drivers_by_score(Catalog c, int N)

--- a/trabalho-pratico/src/model/cities.c
+++ b/trabalho-pratico/src/model/cities.c
@@ -32,16 +32,15 @@ void add_cities_ride(Cities cities, Ride r)
     char *city = get_ride_city(r);
     City found = g_hash_table_lookup(cities, city);
     if (found != NULL) {
-        g_array_append_val(found->rides, r);
+        g_ptr_array_add(found->rides, r);
         found->sum_costs += cost;
         found->n_rides++;
         free(city);
     }
     else {
         City new = g_new(struct city, 1);
-        new->rides =
-            g_array_sized_new(FALSE, FALSE, sizeof(Ride), RESERVED_SIZE);
-        g_array_append_val(new->rides, r);
+        new->rides = g_ptr_array_sized_new(RESERVED_SIZE);
+        g_ptr_array_add(new->rides, r);
         new->sum_costs = cost;
         new->n_rides = 1;
         g_hash_table_insert(cities, city, new);
@@ -70,6 +69,6 @@ static void _key_destroyed(gpointer data)
 static void _value_destroyed(gpointer data)
 {
     City city = (City)data;
-    g_array_free(city->rides, TRUE);
+    g_ptr_array_free(city->rides, TRUE);
     g_free(data);
 }

--- a/trabalho-pratico/src/model/db.c
+++ b/trabalho-pratico/src/model/db.c
@@ -94,7 +94,7 @@ static Users _load_users(FILE *fp)
             }
         }
 
-        insert_user(users, user);
+        add_users_user(users, user);
     }
 
     free(line);
@@ -146,7 +146,7 @@ static Drivers _load_drivers(FILE *fp)
             }
         }
 
-        insert_driver(drivers, driver);
+        add_drivers_driver(drivers, driver);
     }
 
     free(line);
@@ -202,7 +202,7 @@ static Rides _load_rides(FILE *fp)
             }
         }
 
-        add_ride(rides, ride);
+        add_rides_ride(rides, ride);
     }
 
     free(line);

--- a/trabalho-pratico/src/model/drivers.c
+++ b/trabalho-pratico/src/model/drivers.c
@@ -13,19 +13,19 @@ Drivers new_drivers(void)
                                  (GDestroyNotify)_value_destroyed);
 }
 
-gboolean insert_driver(Drivers drivers, Driver d)
+void free_drivers(Drivers drivers)
+{
+    g_hash_table_destroy(g_steal_pointer(&drivers));
+}
+
+gboolean add_drivers_driver(Drivers drivers, Driver d)
 {
     gint *k_id = g_new(gint, 1);
     *k_id = get_driver_id(d);
     return g_hash_table_insert(drivers, k_id, d);
 }
 
-void free_drivers(Drivers drivers)
-{
-    g_hash_table_destroy(g_steal_pointer(&drivers));
-}
-
-Driver get_driver(Drivers drivers, long id)
+Driver get_drivers_driver(Drivers drivers, long id)
 {
     return g_hash_table_lookup(drivers, &id);
 }

--- a/trabalho-pratico/src/model/ride.c
+++ b/trabalho-pratico/src/model/ride.c
@@ -23,11 +23,14 @@ Ride new_ride(void)
     return g_new(struct ride, 1);
 }
 
-void free_ride(Ride *r)
+void free_ride(void *ride)
 {
-    free((*r)->user);
-    free((*r)->city);
-    free(*r);
+    if (ride != NULL) {
+        Ride r = (Ride)ride;
+        free(r->user);
+        free(r->city);
+        free(ride);
+    }
 }
 
 void set_ride_id(Ride r, char *id)

--- a/trabalho-pratico/src/model/rides.c
+++ b/trabalho-pratico/src/model/rides.c
@@ -6,29 +6,32 @@
 #define RESERVED_SIZE 1048576 // (2^20)
 
 static gint _ride_comparator(gconstpointer a, gconstpointer b);
-static guint g_array_binary_search_safe(GArray *array, gconstpointer target,
+static guint g_array_binary_search_safe(GPtrArray *array, gconstpointer target,
                                         GCompareFunc compare_func);
 
 Rides new_rides(void)
 {
-    Rides r = g_array_sized_new(FALSE, FALSE, sizeof(Ride), RESERVED_SIZE);
-    g_array_set_clear_func(r, (GDestroyNotify)free_ride);
-    return r;
-}
-
-void add_ride(Rides rides, Ride ride)
-{
-    g_array_append_val(rides, ride);
+    return g_ptr_array_new_full(RESERVED_SIZE, (GDestroyNotify)free_ride);
 }
 
 void free_rides(Rides rides)
 {
-    g_array_free(rides, TRUE);
+    g_ptr_array_free(rides, TRUE);
+}
+
+void add_rides_ride(Rides rides, Ride ride)
+{
+    g_ptr_array_add(rides, ride);
+}
+
+Ride get_rides_ride(Rides rides, guint index)
+{
+    return g_ptr_array_index(rides, index);
 }
 
 void sort_rides(Rides rides)
 {
-    g_array_sort(rides, (GCompareFunc)_ride_comparator);
+    g_ptr_array_sort(rides, (GCompareFunc)_ride_comparator);
 }
 
 double get_rides_avg_stat_in_range(Rides rides, char *dateA, char *dateB,
@@ -43,10 +46,10 @@ double get_rides_avg_stat_in_range(Rides rides, char *dateA, char *dateB,
     double sum_distance = 0;
     int n_rides = 0;
 
-    for (Ride r = g_array_index(rides, Ride, i);
+    for (Ride r = g_ptr_array_index(rides, i);
          i < rides->len && get_ride_date(r) <= target;
-         r = g_array_index(rides, Ride, ++i)) {
-        sum_distance += (double)get_func(r);
+         r = g_ptr_array_index(rides, ++i)) {
+        sum_distance += get_func(r);
         n_rides++;
     }
 
@@ -60,23 +63,22 @@ static gint _ride_comparator(gconstpointer a, gconstpointer b)
     return get_ride_date(r1) - get_ride_date(r2);
 }
 
-typedef struct _GRealArray GRealArray;
+typedef struct _GRealPtrArray GRealPtrArray;
 
-struct _GRealArray {
-    guint8 *data;
+struct _GRealPtrArray {
+    gpointer *pdata;
     guint len;
-    guint elt_capacity;
-    guint elt_size;
-    guint zero_terminated : 1;
-    guint clear : 1;
+    guint alloc;
     gatomicrefcount ref_count;
-    GDestroyNotify clear_func;
+    guint8 null_terminated; /* always either 0 or 1, so it can be added to array
+                               lengths */
+    GDestroyNotify element_free_func;
 };
 
-static guint g_array_binary_search_safe(GArray *array, gconstpointer target,
+static guint g_array_binary_search_safe(GPtrArray *array, gconstpointer target,
                                         GCompareFunc compare_func)
 {
-    GRealArray *_array = (GRealArray *)array;
+    GRealPtrArray *_array = (GRealPtrArray *)array;
     guint left, middle = 0, right;
     gint val;
 
@@ -90,8 +92,7 @@ static guint g_array_binary_search_safe(GArray *array, gconstpointer target,
         while (left <= right) {
             middle = left + (right - left) / 2;
 
-            val = compare_func(_array->data + (_array->elt_size * middle),
-                               target);
+            val = compare_func(_array->pdata + middle, target);
             if (val == 0)
                 break;
             else if (val < 0)
@@ -104,14 +105,12 @@ static guint g_array_binary_search_safe(GArray *array, gconstpointer target,
     }
 
     while (middle > 0 &&
-           compare_func(target, _array->data +
-                                    (_array->elt_size * (middle - 1))) <= 0) {
+           compare_func(target, _array->pdata + middle - 1) <= 0) {
         middle--;
     }
 
     while (middle < array->len &&
-           compare_func(target, _array->data + (_array->elt_size * middle)) >
-               0) {
+           compare_func(target, _array->pdata + middle) > 0) {
         middle++;
     }
 

--- a/trabalho-pratico/src/model/users.c
+++ b/trabalho-pratico/src/model/users.c
@@ -18,7 +18,7 @@ void free_users(Users users)
     g_hash_table_destroy(g_steal_pointer(&users));
 }
 
-gboolean insert_user(Users users, User u)
+gboolean add_users_user(Users users, User u)
 {
     return g_hash_table_insert(users, get_user_username(u), u);
 }


### PR DESCRIPTION
Initially rides were stored in a [GPtrArray](https://developer-old.gnome.org/glib/stable/glib-Pointer-Arrays.html), an array that only stores pointers, but was changed to a [GArray](https://developer-old.gnome.org/glib/stable/glib-Arrays.html) as the type GPtrArray does not have a binary search function in the glib. Now I've added a binary search function to GPtrArray so we can change rides back to GPtrArray which is more convenient for our use case.

Also fixed some function names and function locations in files.