### PR TITLE
Generalized how output file is opened

### DIFF
--- a/trabalho-pratico/includes/view/ui.h
+++ b/trabalho-pratico/includes/view/ui.h
@@ -2,11 +2,19 @@
 #define __UI_H__
 
 #include <glib.h>
+#include <stdio.h>
 
 typedef struct user *User;
 typedef struct driver *Driver;
 typedef GPtrArray *Query2;
 typedef GPtrArray *Query3;
+
+/**
+ * @brief 
+ * 
+ * @return FILE* 
+ */
+FILE *next_output_file(void);
 
 /**
  * @brief

--- a/trabalho-pratico/src/controller/controller.c
+++ b/trabalho-pratico/src/controller/controller.c
@@ -30,11 +30,14 @@ int run_queries(Catalog c)
 {
     char *query = NULL;
     size_t len = 0;
+    FILE *fp = NULL;
 
     while (getline(&query, &len, stdin) != -1) {
+        fp = next_output_file();
         parse_query(c, query);
     }
 
+    fclose(fp);
     free(query);
 
     return 0;

--- a/trabalho-pratico/src/view/ui.c
+++ b/trabalho-pratico/src/view/ui.c
@@ -5,12 +5,23 @@
 
 static int counter = 1;
 
-void show_query1_user(User u)
+FILE *next_output_file(void)
 {
     char file[64];
     sprintf(file, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(file, "w");
+    return freopen(file, "w", stdout);
+    /*
+    FILE *command_out = freopen(file, "w", stdout);
+    if (command_out == NULL) {
+        perror(file);
+        return 1;
+    }
+    return 0;
+    */
+}
 
+void show_query1_user(User u)
+{
     if (u != NULL) {
         char answer[256];
         char *name = get_user_name(u);
@@ -18,18 +29,12 @@ void show_query1_user(User u)
                 get_user_age(u), get_user_avg_score(u), get_user_n_trips(u),
                 get_user_total_spent(u));
         free(name);
-        fprintf(command_out, "%s\n", answer);
+        printf("%s\n", answer);
     }
-
-    fclose(command_out);
 }
 
 void show_query1_driver(Driver d)
 {
-    char file[64];
-    sprintf(file, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(file, "w");
-
     if (d != NULL) {
         char answer[256];
         char *name = get_driver_name(d);
@@ -37,18 +42,12 @@ void show_query1_driver(Driver d)
                 get_driver_age(d), get_driver_avg_score(d),
                 get_driver_n_trips(d), get_driver_total_earned(d));
         free(name);
-        fprintf(command_out, "%s\n", answer);
+        printf("%s\n", answer);
     }
-
-    fclose(command_out);
 }
 
 void show_query2(Query2 q2)
 {
-    char s[64];
-    sprintf(s, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(s, "w");
-
     char answer[256];
 
     for (guint i = 0; i < q2->len; i++) {
@@ -57,18 +56,12 @@ void show_query2(Query2 q2)
         sprintf(answer, "%012ld;%s;%.3f", get_driver_id(d), name,
                 get_driver_avg_score(d));
         free(name);
-        fprintf(command_out, "%s\n", answer);
+        printf("%s\n", answer);
     }
-
-    fclose(command_out);
 }
 
 void show_query3(Query3 q3)
 {
-    char s[64];
-    sprintf(s, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(s, "w");
-
     char answer[256];
 
     for (guint i = 0; i < q3->len; i++) {
@@ -78,35 +71,21 @@ void show_query3(Query3 q3)
         sprintf(answer, "%s;%s;%d", username, name, get_user_total_distance(u));
         free(username);
         free(name);
-        fprintf(command_out, "%s\n", answer);
+        printf("%s\n", answer);
     }
-
-    fclose(command_out);
 }
 
 void show_query4(double avg_score)
 {
-    char s[64];
-    sprintf(s, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(s, "w");
-    fprintf(command_out, "%.3f\n", avg_score);
-    fclose(command_out);
+    printf("%.3f\n", avg_score);
 }
 
 void show_query5(double avg_cost)
 {
-    char s[64];
-    sprintf(s, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(s, "w");
-    fprintf(command_out, "%.3f\n", avg_cost);
-    fclose(command_out);
+    printf("%.3f\n", avg_cost);
 }
 
 void show_query6(double avg_distance)
 {
-    char s[64];
-    sprintf(s, "./Resultados/command%d_output.txt", counter++);
-    FILE *command_out = fopen(s, "w");
-    fprintf(command_out, "%.3f\n", avg_distance);
-    fclose(command_out);
+    printf("%.3f\n", avg_distance);
 }

--- a/trabalho-pratico/src/view/ui.c
+++ b/trabalho-pratico/src/view/ui.c
@@ -10,15 +10,6 @@ FILE *next_output_file(void)
     char file[64];
     sprintf(file, "./Resultados/command%d_output.txt", counter++);
     return freopen(file, "w", stdout);
-    /*
-    FILE *command_out = freopen(file, "w", stdout);
-    if (command_out == NULL) {
-        perror(file);
-        return 1;
-    }
-    return 0;
-    */
-}
 
 void show_query1_user(User u)
 {


### PR DESCRIPTION
Output files are now all opened in a single function `FILE *next_output_file(void)` by redirecting stdout to this files.

This means that now we only need to print to stdout instead of printing to a specific file possibly simplifying interactive mode implementation.

There might be good reasons not to do this, but I don't know them. Will check with professor on Wednesday.

File opening is still unsafe.